### PR TITLE
Fix password for api users

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,8 +20,8 @@ ggr_ui_version: 1.1.2
 ggr_selenoid_ui_version: 1.10.0
 
 ggr_api_users:
-  ggr-users: 'SuperSecretPass098123'
-  health: 'health'
+  ggr-users: SuperSecretPass123
+  health: health
 
 # consul_service_definition:
 #   - consul-ggr-sevice.json


### PR DESCRIPTION
# Pull Request Template

## Description

Currently without this fix, password will be set as 'health' with quotes not just as health and the same with ggr user pass


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## Reviews

Please identify developer to review this change

- [ ] @developer
